### PR TITLE
Add rich content to previews

### DIFF
--- a/kmp-sharing/src/androidMain/kotlin/com/swmansion/kmpsharing/Sharing.kt
+++ b/kmp-sharing/src/androidMain/kotlin/com/swmansion/kmpsharing/Sharing.kt
@@ -71,14 +71,25 @@ public actual fun rememberShare(): Share {
                     } else {
                         intent.setTypeAndNormalize("text/plain")
                         options?.androidPreviewData?.let { previewData ->
-                            val fileObj = getLocalFileFromUrl(previewData)
-                            val contentUri =
-                                FileProvider.getUriForFile(
-                                    context,
-                                    "${context.packageName}.fileprovider",
-                                    fileObj,
-                                )
-                            val clipData = ClipData.newRawUri(null, contentUri)
+                            val previewUri =
+                                when (getContentType(previewData)) {
+                                    DataType.FILE -> {
+                                        val fileObj = getLocalFileFromUrl(previewData)
+                                        FileProvider.getUriForFile(
+                                            context,
+                                            "${context.packageName}.fileprovider",
+                                            fileObj,
+                                        )
+                                    }
+                                    DataType.CONTENT -> {
+                                        previewData.toUri()
+                                    }
+                                    else ->
+                                        throw IllegalArgumentException(
+                                            "Unsupported preview data type: $previewData"
+                                        )
+                                }
+                            val clipData = ClipData.newRawUri(null, previewUri)
                             intent.clipData = clipData
                         }
                     }

--- a/kmp-sharing/src/androidMain/kotlin/com/swmansion/kmpsharing/Sharing.kt
+++ b/kmp-sharing/src/androidMain/kotlin/com/swmansion/kmpsharing/Sharing.kt
@@ -62,6 +62,7 @@ public actual fun rememberShare(): Share {
                         val mimeType = options?.androidMimeType ?: "image/*"
                         intent.setTypeAndNormalize(mimeType)
                         intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                        intent.data = contentUris[0]
                     } else {
                         intent.setTypeAndNormalize("text/plain")
                     }

--- a/kmp-sharing/src/androidMain/kotlin/com/swmansion/kmpsharing/Sharing.kt
+++ b/kmp-sharing/src/androidMain/kotlin/com/swmansion/kmpsharing/Sharing.kt
@@ -22,17 +22,6 @@ public actual fun rememberShare(): Share {
 
                     val contentUris = mutableListOf<Uri>()
                     val textItems = mutableListOf<String>()
-                    var previewUri: Uri? = null
-
-                    options?.androidPreviewData?.let { previewData ->
-                        val fileObj = getLocalFileFromUrl(previewData)
-                        previewUri =
-                            FileProvider.getUriForFile(
-                                context,
-                                "${context.packageName}.fileprovider",
-                                fileObj,
-                            )
-                    }
 
                     data.forEach { file ->
                         when (getContentType(file)) {
@@ -74,12 +63,22 @@ public actual fun rememberShare(): Share {
                         }
 
                         val mimeType = options?.androidMimeType ?: "image/*"
+                        require(options?.androidPreviewData == null) {
+                            "Custom preview data is not supported for sharing images."
+                        }
                         intent.setTypeAndNormalize(mimeType)
-                        intent.data = previewUri ?: contentUris[0]
+                        intent.data = contentUris[0]
                     } else {
                         intent.setTypeAndNormalize("text/plain")
                         options?.androidPreviewData?.let { previewData ->
-                            val clipData = ClipData.newRawUri(null, previewUri)
+                            val fileObj = getLocalFileFromUrl(previewData)
+                            val contentUri =
+                                FileProvider.getUriForFile(
+                                    context,
+                                    "${context.packageName}.fileprovider",
+                                    fileObj,
+                                )
+                            val clipData = ClipData.newRawUri(null, contentUri)
                             intent.clipData = clipData
                         }
                     }

--- a/kmp-sharing/src/androidMain/kotlin/com/swmansion/kmpsharing/Sharing.kt
+++ b/kmp-sharing/src/androidMain/kotlin/com/swmansion/kmpsharing/Sharing.kt
@@ -50,7 +50,6 @@ public actual fun rememberShare(): Share {
                             if (contentUris.size > 1) Intent.ACTION_SEND_MULTIPLE
                             else Intent.ACTION_SEND
                         )
-                    intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
 
                     if (contentUris.isNotEmpty()) {
                         if (contentUris.size == 1) {
@@ -96,6 +95,10 @@ public actual fun rememberShare(): Share {
 
                     if (textItems.isNotEmpty()) {
                         intent.putExtra(Intent.EXTRA_TEXT, textItems.joinToString("\n"))
+                    }
+
+                    if (intent.data != null || intent.clipData != null) {
+                        intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
                     }
 
                     options?.androidDialogTitle?.let { title ->

--- a/kmp-sharing/src/commonMain/kotlin/com/swmansion/kmpsharing/SharingRecords.kt
+++ b/kmp-sharing/src/commonMain/kotlin/com/swmansion/kmpsharing/SharingRecords.kt
@@ -7,7 +7,7 @@ package com.swmansion.kmpsharing
  * @param iosUTI iOS Uniform Type Identifier for file type recognition
  * @param androidDialogTitle Title for Android share dialog
  * @param androidMimeType MIME type override for Android (auto-detected if null)
- * @param androidPreviewData Rich content preview image path for Android (auto-detected if null)
+ * @param androidPreviewData Preview image path for Android URL and text sharing
  */
 public data class SharingOptions(
     val iosAnchor: Anchor? = null,

--- a/kmp-sharing/src/commonMain/kotlin/com/swmansion/kmpsharing/SharingRecords.kt
+++ b/kmp-sharing/src/commonMain/kotlin/com/swmansion/kmpsharing/SharingRecords.kt
@@ -7,12 +7,14 @@ package com.swmansion.kmpsharing
  * @param iosUTI iOS Uniform Type Identifier for file type recognition
  * @param androidDialogTitle Title for Android share dialog
  * @param androidMimeType MIME type override for Android (auto-detected if null)
+ * @param androidPreviewData Rich content preview image path for Android (auto-detected if null)
  */
 public data class SharingOptions(
     val iosAnchor: Anchor? = null,
     val iosUTI: String? = null,
     val androidDialogTitle: String? = null,
     val androidMimeType: String? = null,
+    val androidPreviewData: String? = null,
 )
 
 /**


### PR DESCRIPTION
The preview was added to image sharing by default. For link/text sharing it is possible to pass a path to the image that will serve as a thumbnail.

<img width="270" height="600" alt="Screenshot_20251023_155430" src="https://github.com/user-attachments/assets/5eadf82d-bfa2-41c8-802a-12b1d4e86a0c" />

<img width="270" height="600" alt="Screenshot_20251023_161821" src="https://github.com/user-attachments/assets/4372d154-77a5-4b9d-ba0c-a744e216fa50" />
