### PR TITLE
Add bitmap generation

### DIFF
--- a/sample/src/androidMain/kotlin/com/swmansion/kmpsharing/sample/Utils.android.kt
+++ b/sample/src/androidMain/kotlin/com/swmansion/kmpsharing/sample/Utils.android.kt
@@ -1,0 +1,74 @@
+package com.swmansion.kmpsharing.sample
+
+
+import android.content.ContentValues
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.net.Uri
+import android.os.Build
+import android.provider.MediaStore
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.graphics.createBitmap
+import java.io.OutputStream
+import kotlin.random.Random
+
+@Composable
+actual fun createAndSaveTestBitmap(): String? {
+    // 1. Create a Bitmap with random colors
+    val width = 512
+    val height = 512
+    val bitmap = createBitmap(width, height)
+    val canvas = Canvas(bitmap)
+    val paint = Paint()
+
+    // Fill background with a random color
+    paint.color = Color.rgb(Random.nextInt(256), Random.nextInt(256), Random.nextInt(256))
+    canvas.drawRect(0f, 0f, width.toFloat(), height.toFloat(), paint)
+
+    // Draw some random circles
+    repeat(5) {
+        paint.color = Color.rgb(Random.nextInt(256), Random.nextInt(256), Random.nextInt(256))
+        val radius = Random.nextInt(20, 100).toFloat()
+        val cx = Random.nextInt(radius.toInt(), width - radius.toInt()).toFloat()
+        val cy = Random.nextInt(radius.toInt(), height - radius.toInt()).toFloat()
+        canvas.drawCircle(cx, cy, radius, paint)
+    }
+
+    // 2. Save to MediaStore
+    val displayName = "test_image_${System.currentTimeMillis()}"
+    val imageCollection: Uri = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        MediaStore.Images.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)
+    } else {
+        MediaStore.Images.Media.EXTERNAL_CONTENT_URI
+    }
+
+    val contentValues = ContentValues().apply {
+        put(MediaStore.Images.Media.DISPLAY_NAME, "$displayName.jpg")
+        put(MediaStore.Images.Media.MIME_TYPE, "image/jpeg")
+        put(MediaStore.Images.Media.WIDTH, bitmap.width)
+        put(MediaStore.Images.Media.HEIGHT, bitmap.height)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            put(MediaStore.Images.Media.IS_PENDING, 1)
+        }
+    }
+
+    val contentResolver = LocalContext.current.contentResolver
+    val uri: Uri? = contentResolver.insert(imageCollection, contentValues)
+
+    uri?.let {
+        contentResolver.openOutputStream(it)?.use { outputStream: OutputStream ->
+            bitmap.compress(Bitmap.CompressFormat.JPEG, 100, outputStream)
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            contentValues.clear()
+            contentValues.put(MediaStore.Images.Media.IS_PENDING, 0)
+            contentResolver.update(uri, contentValues, null, null)
+        }
+    }
+
+    return uri.toString()
+}

--- a/sample/src/androidMain/kotlin/com/swmansion/kmpsharing/sample/Utils.android.kt
+++ b/sample/src/androidMain/kotlin/com/swmansion/kmpsharing/sample/Utils.android.kt
@@ -1,6 +1,5 @@
 package com.swmansion.kmpsharing.sample
 
-
 import android.content.ContentValues
 import android.graphics.Bitmap
 import android.graphics.Canvas
@@ -17,18 +16,15 @@ import kotlin.random.Random
 
 @Composable
 actual fun createAndSaveTestBitmap(): String? {
-    // 1. Create a Bitmap with random colors
     val width = 512
     val height = 512
     val bitmap = createBitmap(width, height)
     val canvas = Canvas(bitmap)
     val paint = Paint()
 
-    // Fill background with a random color
     paint.color = Color.rgb(Random.nextInt(256), Random.nextInt(256), Random.nextInt(256))
     canvas.drawRect(0f, 0f, width.toFloat(), height.toFloat(), paint)
 
-    // Draw some random circles
     repeat(5) {
         paint.color = Color.rgb(Random.nextInt(256), Random.nextInt(256), Random.nextInt(256))
         val radius = Random.nextInt(20, 100).toFloat()
@@ -37,23 +33,24 @@ actual fun createAndSaveTestBitmap(): String? {
         canvas.drawCircle(cx, cy, radius, paint)
     }
 
-    // 2. Save to MediaStore
     val displayName = "test_image_${System.currentTimeMillis()}"
-    val imageCollection: Uri = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-        MediaStore.Images.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)
-    } else {
-        MediaStore.Images.Media.EXTERNAL_CONTENT_URI
-    }
-
-    val contentValues = ContentValues().apply {
-        put(MediaStore.Images.Media.DISPLAY_NAME, "$displayName.jpg")
-        put(MediaStore.Images.Media.MIME_TYPE, "image/jpeg")
-        put(MediaStore.Images.Media.WIDTH, bitmap.width)
-        put(MediaStore.Images.Media.HEIGHT, bitmap.height)
+    val imageCollection: Uri =
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            put(MediaStore.Images.Media.IS_PENDING, 1)
+            MediaStore.Images.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)
+        } else {
+            MediaStore.Images.Media.EXTERNAL_CONTENT_URI
         }
-    }
+
+    val contentValues =
+        ContentValues().apply {
+            put(MediaStore.Images.Media.DISPLAY_NAME, "$displayName.jpg")
+            put(MediaStore.Images.Media.MIME_TYPE, "image/jpeg")
+            put(MediaStore.Images.Media.WIDTH, bitmap.width)
+            put(MediaStore.Images.Media.HEIGHT, bitmap.height)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                put(MediaStore.Images.Media.IS_PENDING, 1)
+            }
+        }
 
     val contentResolver = LocalContext.current.contentResolver
     val uri: Uri? = contentResolver.insert(imageCollection, contentValues)

--- a/sample/src/androidMain/kotlin/com/swmansion/kmpsharing/sample/Utils.android.kt
+++ b/sample/src/androidMain/kotlin/com/swmansion/kmpsharing/sample/Utils.android.kt
@@ -16,8 +16,8 @@ import kotlin.random.Random
 
 @Composable
 actual fun createAndSaveTestBitmap(): String? {
-    val width = 512
-    val height = 512
+    val width = TEST_IMAGE_WIDTH
+    val height = TEST_IMAGE_HEIGHT
     val bitmap = createBitmap(width, height)
     val canvas = Canvas(bitmap)
     val paint = Paint()

--- a/sample/src/commonMain/kotlin/com/swmansion/kmpsharing/sample/App.kt
+++ b/sample/src/commonMain/kotlin/com/swmansion/kmpsharing/sample/App.kt
@@ -13,7 +13,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -27,7 +27,6 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 @Preview
 fun App() {
     val share = rememberShare()
-    val bitmap = createAndSaveTestBitmap() ?: ""
 
     MaterialTheme {
         Box(modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background)) {
@@ -39,7 +38,8 @@ fun App() {
                 Button(
                     onClick = {
                         share(
-                            data = bitmap,
+                            data =
+                                "https://blog.swmansion.com/reanimated-4-stable-release-the-future-of-react-native-animations-ba68210c3713",
                             options =
                                 SharingOptions(
                                     android =

--- a/sample/src/commonMain/kotlin/com/swmansion/kmpsharing/sample/App.kt
+++ b/sample/src/commonMain/kotlin/com/swmansion/kmpsharing/sample/App.kt
@@ -39,8 +39,7 @@ fun App() {
                 Button(
                     onClick = {
                         share(
-                            data =
-                                "https://blog.swmansion.com/reanimated-4-stable-release-the-future-of-react-native-animations-ba68210c3713",
+                            data = bitmap,
                             options =
                                 SharingOptions(
                                     android =

--- a/sample/src/commonMain/kotlin/com/swmansion/kmpsharing/sample/App.kt
+++ b/sample/src/commonMain/kotlin/com/swmansion/kmpsharing/sample/App.kt
@@ -13,7 +13,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -27,6 +27,7 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 @Preview
 fun App() {
     val share = rememberShare()
+    val bitmap = createAndSaveTestBitmap() ?: ""
 
     MaterialTheme {
         Box(modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background)) {

--- a/sample/src/commonMain/kotlin/com/swmansion/kmpsharing/sample/Utils.kt
+++ b/sample/src/commonMain/kotlin/com/swmansion/kmpsharing/sample/Utils.kt
@@ -1,0 +1,6 @@
+package com.swmansion.kmpsharing.sample
+
+import androidx.compose.runtime.Composable
+
+@Composable
+expect fun createAndSaveTestBitmap(): String?

--- a/sample/src/commonMain/kotlin/com/swmansion/kmpsharing/sample/Utils.kt
+++ b/sample/src/commonMain/kotlin/com/swmansion/kmpsharing/sample/Utils.kt
@@ -2,4 +2,7 @@ package com.swmansion.kmpsharing.sample
 
 import androidx.compose.runtime.Composable
 
+const val TEST_IMAGE_WIDTH = 512
+const val TEST_IMAGE_HEIGHT = 512
+
 @Composable expect fun createAndSaveTestBitmap(): String?

--- a/sample/src/commonMain/kotlin/com/swmansion/kmpsharing/sample/Utils.kt
+++ b/sample/src/commonMain/kotlin/com/swmansion/kmpsharing/sample/Utils.kt
@@ -2,5 +2,4 @@ package com.swmansion.kmpsharing.sample
 
 import androidx.compose.runtime.Composable
 
-@Composable
-expect fun createAndSaveTestBitmap(): String?
+@Composable expect fun createAndSaveTestBitmap(): String?

--- a/sample/src/iosMain/kotlin/com/swmansion/kmpsharing/sample/Utils.ios.kt
+++ b/sample/src/iosMain/kotlin/com/swmansion/kmpsharing/sample/Utils.ios.kt
@@ -1,0 +1,8 @@
+package com.swmansion.kmpsharing.sample
+
+import androidx.compose.runtime.Composable
+
+@Composable
+actual fun createAndSaveTestBitmap(): String? {
+    TODO("Not yet implemented")
+}

--- a/sample/src/iosMain/kotlin/com/swmansion/kmpsharing/sample/Utils.ios.kt
+++ b/sample/src/iosMain/kotlin/com/swmansion/kmpsharing/sample/Utils.ios.kt
@@ -15,17 +15,15 @@ actual fun createAndSaveTestBitmap(): String? {
     val size = CGSizeMake(width, height)
 
     UIGraphicsBeginImageContextWithOptions(size, true, 1.0)
-    val ctx = UIGraphicsGetCurrentContext() ?: run {
-        UIGraphicsEndImageContext()
-        return null
-    }
+    val ctx =
+        UIGraphicsGetCurrentContext()
+            ?: run {
+                UIGraphicsEndImageContext()
+                return null
+            }
 
-    val bgColor = UIColor.colorWithRed(
-        Random.nextDouble(),
-        Random.nextDouble(),
-        Random.nextDouble(),
-        1.0
-    )
+    val bgColor =
+        UIColor.colorWithRed(Random.nextDouble(), Random.nextDouble(), Random.nextDouble(), 1.0)
     CGContextSetFillColorWithColor(ctx, bgColor.CGColor)
     CGContextFillRect(ctx, CGRectMake(0.0, 0.0, width, height))
 
@@ -33,12 +31,8 @@ actual fun createAndSaveTestBitmap(): String? {
         val radius = Random.nextInt(20, 100).toDouble()
         val cx = Random.nextDouble(radius, width - radius)
         val cy = Random.nextDouble(radius, height - radius)
-        val circleColor = UIColor.colorWithRed(
-            Random.nextDouble(),
-            Random.nextDouble(),
-            Random.nextDouble(),
-            1.0
-        )
+        val circleColor =
+            UIColor.colorWithRed(Random.nextDouble(), Random.nextDouble(), Random.nextDouble(), 1.0)
         CGContextSetFillColorWithColor(ctx, circleColor.CGColor)
         val circleRect = CGRectMake(cx - radius, cy - radius, radius * 2, radius * 2)
         CGContextFillEllipseInRect(ctx, circleRect)

--- a/sample/src/iosMain/kotlin/com/swmansion/kmpsharing/sample/Utils.ios.kt
+++ b/sample/src/iosMain/kotlin/com/swmansion/kmpsharing/sample/Utils.ios.kt
@@ -10,8 +10,8 @@ import platform.UIKit.*
 @OptIn(ExperimentalForeignApi::class)
 @Composable
 actual fun createAndSaveTestBitmap(): String? {
-    val width = 512.0
-    val height = 512.0
+    val width = TEST_IMAGE_WIDTH.toDouble()
+    val height = TEST_IMAGE_HEIGHT.toDouble()
     val size = CGSizeMake(width, height)
 
     UIGraphicsBeginImageContextWithOptions(size, true, 1.0)

--- a/sample/src/iosMain/kotlin/com/swmansion/kmpsharing/sample/Utils.ios.kt
+++ b/sample/src/iosMain/kotlin/com/swmansion/kmpsharing/sample/Utils.ios.kt
@@ -1,8 +1,60 @@
 package com.swmansion.kmpsharing.sample
 
 import androidx.compose.runtime.Composable
+import kotlin.random.Random
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.CoreGraphics.*
+import platform.Foundation.*
+import platform.UIKit.*
 
+@OptIn(ExperimentalForeignApi::class)
 @Composable
 actual fun createAndSaveTestBitmap(): String? {
-    TODO("Not yet implemented")
+    val width = 512.0
+    val height = 512.0
+    val size = CGSizeMake(width, height)
+
+    UIGraphicsBeginImageContextWithOptions(size, true, 1.0)
+    val ctx = UIGraphicsGetCurrentContext() ?: run {
+        UIGraphicsEndImageContext()
+        return null
+    }
+
+    val bgColor = UIColor.colorWithRed(
+        Random.nextDouble(),
+        Random.nextDouble(),
+        Random.nextDouble(),
+        1.0
+    )
+    CGContextSetFillColorWithColor(ctx, bgColor.CGColor)
+    CGContextFillRect(ctx, CGRectMake(0.0, 0.0, width, height))
+
+    repeat(5) {
+        val radius = Random.nextInt(20, 100).toDouble()
+        val cx = Random.nextDouble(radius, width - radius)
+        val cy = Random.nextDouble(radius, height - radius)
+        val circleColor = UIColor.colorWithRed(
+            Random.nextDouble(),
+            Random.nextDouble(),
+            Random.nextDouble(),
+            1.0
+        )
+        CGContextSetFillColorWithColor(ctx, circleColor.CGColor)
+        val circleRect = CGRectMake(cx - radius, cy - radius, radius * 2, radius * 2)
+        CGContextFillEllipseInRect(ctx, circleRect)
+    }
+
+    val image = UIGraphicsGetImageFromCurrentImageContext()
+    UIGraphicsEndImageContext()
+    if (image == null) return null
+
+    val data = UIImageJPEGRepresentation(image, 1.0) ?: return null
+    val filename = "test_image_${NSDate().timeIntervalSince1970}.jpg"
+    val path = (NSTemporaryDirectory() as NSString).stringByAppendingPathComponent(filename)
+
+    return if (data.writeToFile(path, true)) {
+        "file://$path"
+    } else {
+        null
+    }
 }


### PR DESCRIPTION
For the simplicity of showing image sharing, a bitmap generation and download util has been added.
<img width="216" height="480" alt="Screenshot_20251103_100933" src="https://github.com/user-attachments/assets/4e28dcbd-30e3-42b3-843f-615e989db49e" />
<img width="216" height="480" alt="Simulator Screenshot - iPhone 16 - 2025-11-03 at 10 41 13" src="https://github.com/user-attachments/assets/74b25189-4f7c-4290-b9c7-f0cf026606c7" />
